### PR TITLE
fix fft test

### DIFF
--- a/kymatio/scattering2d/filter_bank.py
+++ b/kymatio/scattering2d/filter_bank.py
@@ -53,7 +53,7 @@ def filter_bank(M, N, J, L=8):
                 psi_signal_fourier_res = psi_signal_fourier_res[..., np.newaxis]
                 psi[res] = psi_signal_fourier_res
                 # Normalization to avoid doing it with the FFT.
-                psi[res] /= M*N// 2**(2*j)
+                #psi[res] *= M*N// 2**(2*j)
 
             filters['psi'].append(psi)
 
@@ -69,7 +69,7 @@ def filter_bank(M, N, J, L=8):
         phi_signal_fourier_res = phi_signal_fourier_res[..., np.newaxis]
         filters['phi'][res] = phi_signal_fourier_res
         # Normalization to avoid doing it with the FFT.
-        filters['phi'][res] /= M*N // 2 ** (2 * J)
+        filters['phi'][res] *= M*N // 2 ** (2 * J)
 
     return filters
 


### PR DESCRIPTION
just a small fix such that(please check if on your platform..):

I have **not** modified the skcuda backend in purpose.

```
scattering2d oyallon$ pytest
================================================================= test session starts ==================================================================
platform darwin -- Python 3.5.6, pytest-3.8.1, py-1.6.0, pluggy-0.11.0
rootdir: /Users/oyallon/kymatio, inifile:
plugins: cov-2.7.1
collected 12 items                                                                                                                                     

tests/test_scattering2d.py ............                                                                                                          [100%]

============================================================== 12 passed in 17.33 seconds ==============================================================
```